### PR TITLE
Removes Dependency On faraday_middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,4 @@ client.disconnect
 
 * httpclient
 * faraday
-* faraday-middleware
 

--- a/lib/synowebapi/client.rb
+++ b/lib/synowebapi/client.rb
@@ -1,6 +1,5 @@
 
 require 'faraday'
-require 'faraday_middleware'
 require 'synowebapi/api'
 
 module SYNOWebAPI

--- a/lib/synowebapi/version.rb
+++ b/lib/synowebapi/version.rb
@@ -1,5 +1,5 @@
 
 module SYNOWebAPI
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end
 

--- a/synowebapi.gemspec
+++ b/synowebapi.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httpclient'
   s.add_dependency 'faraday'
-  s.add_dependency 'faraday_middleware'
 end


### PR DESCRIPTION
It does not appear this library actually dependds on faraday_middleware, so hopefully it is safe to remove it.